### PR TITLE
Fix cross-platform build archiving

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
         python-version: ['3.11']
+        include:
+          - os: ubuntu-latest
+            archive-ext: tar.gz
+          - os: macos-14
+            archive-ext: tar.gz
+          - os: windows-latest
+            archive-ext: zip
 
     steps:
       - name: Checkout
@@ -52,17 +59,24 @@ jobs:
         run: |
           pyinstaller --noconfirm --onedir --name TranslatorHoi4 --icon assets/icon.png translatorhoi4/app.py
 
-      - name: Archive
+      - name: Archive (Windows)
+        if: runner.os == 'Windows'
         run: |
           cd dist
-          zip -r ../TranslatorHoi4-${{ runner.os }}-${{ runner.arch }}.zip TranslatorHoi4
+          Compress-Archive -Path TranslatorHoi4 -DestinationPath "..\\TranslatorHoi4-${{ runner.os }}-${{ runner.arch }}.${{ matrix.archive-ext }}"
+
+      - name: Archive (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd dist
+          tar -czf ../TranslatorHoi4-${{ runner.os }}-${{ runner.arch }}.${{ matrix.archive-ext }} TranslatorHoi4
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: TranslatorHoi4-${{ runner.os }}-${{ runner.arch }}
           path: |
-            TranslatorHoi4-${{ runner.os }}-${{ runner.arch }}.zip
+            TranslatorHoi4-${{ runner.os }}-${{ runner.arch }}.${{ matrix.archive-ext }}
 
   release:
     needs: build

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ model = "gemini-2.5-flash"
 
 Справочник: https://github.com/gpt4free/g4f.dev/blob/main/docs/providers-and-models.md
 
-## Сборка (Linux)
+## Сборка
 
 Убедитесь, что файл `assets/icon.png` (64×64) существует.
+Сборка выполняется PyInstaller в режиме `--onedir`, поэтому
+результатом является каталог с необходимыми зависимостями. В GitHub
+Actions для Windows создаётся архив ZIP, а для Linux и macOS – TAR.GZ.
 
 ```bash
 pyinstaller --noconfirm --onedir --name TranslatorHoi4 --icon assets/icon.png translatorhoi4/app.py


### PR DESCRIPTION
## Summary
- Handle Windows archiving with Compress-Archive and use tar.gz for Unix runners
- Document cross-platform onedir build output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1f14549c4832a8f276cd25d21f9c6