### PR TITLE
Add IO Intelligence API backend and UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ g4f[all]
 gradio_client>=0.15
 deep-translator>=1.11.4
 googletrans
+openai>=1.0.0
+requests>=2.31.0
 pyinstaller>=6.3
 pytest>=7.4

--- a/translatorhoi4.spec
+++ b/translatorhoi4.spec
@@ -22,6 +22,8 @@ for pkg in [
     "googletrans",
     "deep_translator",
     "gradio_client",
+    "openai",
+    "requests",
     "regex",
     "certifi",
     "httpx",
@@ -65,7 +67,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=["speech_recognition"],
     noarchive=False,
 )
 

--- a/translatorhoi4/translator/backends.py
+++ b/translatorhoi4/translator/backends.py
@@ -99,6 +99,8 @@ def _cleanup_llm_output(text: str) -> str:
 
 def _strip_model_noise(text: str) -> str:
     t = text.strip()
+    # Remove reasoning tags like <think>...</think>
+    t = re.sub(r"<think>.*?</think>", "", t, flags=re.DOTALL | re.IGNORECASE)
     if t.startswith("```") and t.endswith("```"):
         t = t.strip('`')
         lines = t.splitlines()
@@ -501,6 +503,120 @@ class G4F_Backend(TranslationBackend):
                         model=self.model,
                         messages=self._messages(sys_prompt, payload),
                         web_search=self.web_search,
+                        temperature=self.temperature,
+                    )
+                    content = res.choices[0].message.content if hasattr(res, "choices") else _extract_text(res)
+                    if not _looks_like_http_error(content):
+                        raw = _strip_model_noise(_cleanup_llm_output(_extract_text(content)))
+                        return _extract_marked(raw, sid)
+                except Exception:
+                    pass
+            await asyncio.sleep(delay)
+            delay = min(3.0, delay * 1.7)
+        return text
+
+    def translate_many(self, texts: List[str], src_lang: str, dst_lang: str) -> List[str]:
+        if not self.async_mode:
+            return [self.translate(t, src_lang, dst_lang) for t in texts]
+        self._init_async()
+        sem = asyncio.Semaphore(self.concurrency)
+
+        async def runner():
+            tasks = [self._async_translate_one(self._aclient, sem, t, src_lang, dst_lang) for t in texts]
+            return await asyncio.gather(*tasks, return_exceptions=False)
+
+        try:
+            return self._loop.run_until_complete(runner())
+        except Exception:
+            try:
+                return asyncio.run(runner())
+            except Exception:
+                return [self.translate(t, src_lang, dst_lang) for t in texts]
+
+
+# --- IO Intelligence Backend ---
+
+class IO_Intelligence_Backend(TranslationBackend):
+    name = "IO: chat.completions"
+    supports_batch = True
+    supports_system_prompt = True
+
+    def __init__(self, api_key: Optional[str], model: str, base_url: str,
+                 temperature: float = 0.7, async_mode: bool = True,
+                 concurrency: int = 6, max_retries: int = 4):
+        self.api_key = (api_key or "").strip() or None
+        self.model = (model or "meta-llama/Llama-3.3-70B-Instruct").strip()
+        self.base_url = (base_url or "https://api.intelligence.io.solutions/api/v1/").strip()
+        self.temperature = float(temperature)
+        self.async_mode = bool(async_mode)
+        self.concurrency = max(1, int(concurrency))
+        self.max_retries = max(1, int(max_retries))
+        self._client = None
+        self._aclient = None
+        self._init_lock = threading.Lock()
+        self._loop = None
+
+    def _init_sync(self):
+        with self._init_lock:
+            if self._client is not None:
+                return
+            import openai
+            self._client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    def _init_async(self):
+        with self._init_lock:
+            if self._aclient is not None and self._loop is not None:
+                return
+            import openai
+            self._aclient = openai.AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
+            try:
+                self._loop = asyncio.new_event_loop()
+            except Exception:
+                self._loop = asyncio.get_event_loop()
+
+    def warmup(self):
+        if self.async_mode:
+            self._init_async()
+        else:
+            self._init_sync()
+
+    def _messages(self, sys_prompt: str, payload: str):
+        return [{"role": "system", "content": sys_prompt}, {"role": "user", "content": payload}]
+
+    def translate(self, text: str, src_lang: str, dst_lang: str) -> str:
+        self._init_sync()
+        sid = hashlib.md5(text.encode("utf-8")).hexdigest()[:10]
+        payload = wrap_with_markers(text, sid)
+        sys_prompt = system_prompt(src_lang, dst_lang)
+        delay = 0.5
+        for attempt in range(self.max_retries):
+            try:
+                res = self._client.chat.completions.create(
+                    model=self.model,
+                    messages=self._messages(sys_prompt, payload),
+                    temperature=self.temperature,
+                )
+                content = res.choices[0].message.content if hasattr(res, "choices") else _extract_text(res)
+                if not _looks_like_http_error(content):
+                    raw = _strip_model_noise(_cleanup_llm_output(_extract_text(content)))
+                    return _extract_marked(raw, sid)
+            except Exception:
+                pass
+            time.sleep(delay)
+            delay = min(5.0, delay * 1.7)
+        return text
+
+    async def _async_translate_one(self, aclient, sem, text: str, src_lang: str, dst_lang: str):
+        sid = hashlib.md5(text.encode("utf-8")).hexdigest()[:10]
+        payload = wrap_with_markers(text, sid)
+        sys_prompt = system_prompt(src_lang, dst_lang)
+        delay = 0.3
+        for attempt in range(self.max_retries):
+            async with sem:
+                try:
+                    res = await aclient.chat.completions.create(
+                        model=self.model,
+                        messages=self._messages(sys_prompt, payload),
                         temperature=self.temperature,
                     )
                     content = res.choices[0].message.content if hasattr(res, "choices") else _extract_text(res)

--- a/translatorhoi4/utils/version.py
+++ b/translatorhoi4/utils/version.py
@@ -1,2 +1,2 @@
 """Version info."""
-__version__ = "1.0"
+__version__ = "1.1"


### PR DESCRIPTION
## Summary
- integrate IO Intelligence chat completion backend with async support
- add UI and model fetching for IO Intelligence along with loading indicator
- update spec to exclude speech_recognition and remove GIF asset
- bump version to 1.1

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62c54348c832abc70b9e6d8173116